### PR TITLE
opt in to telemetry collection for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - dotnet run --project validator/ hello_world.docx
 env:
   global:
-    - DOTNET_CLI_TELEMETRY_OPTOUT=0
+    - DOTNET_CLI_TELEMETRY_OPTOUT=1
 notifications:
   email:
     on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ script:
   - cargo test
   - cargo run --example hello_world
   - dotnet run --project validator/ hello_world.docx
-
+env:
+  global:
+    - DOTNET_CLI_TELEMETRY_OPTOUT=0
 notifications:
   email:
     on_failure: change


### PR DESCRIPTION
@PoiScript let me know if you would prefer otherwise, but it seems sensible to allow telemetry collection for dotnet in CI.
This should hopefully disable the noise: https://travis-ci.org/PoiScript/docx-rs/builds/636260111#L398

You can read about what they collect [here](https://aka.ms/dotnet-cli-telemetry)