### PR TITLE
add example table usage

### DIFF
--- a/docx/examples/table.rs
+++ b/docx/examples/table.rs
@@ -1,0 +1,20 @@
+use docx::formatting::TableProperty;
+use docx::{document::Table, document::TableGrid, document::TableRow, Docx, Result};
+
+fn main() -> Result<()> {
+    // create an empty document
+    let mut docx = Docx::default();
+
+    // create a table and populate it with data
+    let tbl = Table::default()
+        .prop(TableProperty::default())
+        .push_grid(vec![1, 2, 3])
+        .push_grid(TableGrid::default())
+        .push_row(TableRow::default());
+    // add the table to the document
+    docx.document.push(tbl);
+    // persist the document to a file
+    docx.write_file("table.docx")?;
+
+    Ok(())
+}


### PR DESCRIPTION
The example runs correctly, but the Word document does not open in Microsoft Word on macOS.
I opened #18 to track that.