### PR TITLE
Add wasm32 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["docx", "generator", "openxml", "parser"]
 derive_more = "0.99.5"
 log = "0.4.8"
 strong-xml = { version = "0.5.0", features = ["log"] }
-zip = "0.5.5"
+zip = { version = "0.5.5", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 env_logger = "0.7.1"


### PR DESCRIPTION
zip-rs currently have `bzip2` as default feature which doesn't compile in wasm.
I didn't find documentation in the ooxml specification but from all docx I've tested none of them was compress in `bz2ip`.
So this PR allow docx-rs compilation to wasm by removing feature from zip-rs.

Sources:
https://github.com/zip-rs/zip/blob/f5d7b6c89544af3b0d6a39a8b0ac3e35aff4f7d7/README.md#usage
https://github.com/zip-rs/zip/blob/master/Cargo.toml#L32