### PR TITLE
General improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 *.docx
 Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ description = "A Rust library for parsing and generating docx files."
 keywords = ["docx", "generator", "openxml", "parser"]
 
 [dependencies]
-derive_more = "0.99.5"
-log = "0.4.8"
-strong-xml = { version = "0.5.0", features = ["log"] }
-zip = "0.5.5"
+derive_more = "0.99"
+log = "0.4"
+strong-xml = { version = "0.6", features = ["log"] }
+zip = "0.5"
 
 [dev-dependencies]
-env_logger = "0.7.1"
+env_logger = "0.8"

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -38,7 +38,7 @@ fn main() -> DocxResult<()> {
                 .push_text("hello, world"),
         );
 
-    docx.document.push(para);
+    docx.document.add_content(para);
 
     // Insert a centered paragraph with an outline
     let para = Paragraph::default()
@@ -53,7 +53,7 @@ fn main() -> DocxResult<()> {
                 .push_text("hello, world"),
         );
 
-    docx.document.push(para);
+    docx.document.add_content(para);
 
     // Insert a right-aligned, italics paragraph
     let para = Paragraph::default()
@@ -69,7 +69,7 @@ fn main() -> DocxResult<()> {
                 .push_text("world"),
         );
 
-    docx.document.push(para);
+    docx.document.add_content(para);
 
     docx.write_file("hello_world.docx")?;
 

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -24,7 +24,7 @@ fn main() -> DocxResult<()> {
         );
 
     // Add the table to the document
-    docx.document.push(tbl);
+    docx.document.add_content(tbl);
 
     // Persist the document to a file
     docx.write_file("table.docx")?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -117,52 +117,52 @@ impl<'a> XmlWrite for App<'a> {
         } else {
             writer.write_element_end_open()?;
             if let Some(val) = template {
-                writer.write_flatten_text("Template", val)?;
+                writer.write_flatten_text("Template", val, false)?;
             }
             if let Some(val) = total_time {
-                writer.write_flatten_text("TotalTime", val)?;
+                writer.write_flatten_text("TotalTime", val, false)?;
             }
             if let Some(val) = pages {
-                writer.write_flatten_text("Pages", val)?;
+                writer.write_flatten_text("Pages", val, false)?;
             }
             if let Some(val) = words {
-                writer.write_flatten_text("Words", val)?;
+                writer.write_flatten_text("Words", val, false)?;
             }
             if let Some(val) = characters {
-                writer.write_flatten_text("Characters", val)?;
+                writer.write_flatten_text("Characters", val, false)?;
             }
             if let Some(val) = application {
-                writer.write_flatten_text("Application", val)?;
+                writer.write_flatten_text("Application", val, false)?;
             }
             if let Some(val) = doc_security {
-                writer.write_flatten_text("DocSecurity", val)?;
+                writer.write_flatten_text("DocSecurity", val, false)?;
             }
             if let Some(val) = lines {
-                writer.write_flatten_text("Lines", val)?;
+                writer.write_flatten_text("Lines", val, false)?;
             }
             if let Some(val) = paragraphs {
-                writer.write_flatten_text("Paragraphs", val)?;
+                writer.write_flatten_text("Paragraphs", val, false)?;
             }
             if let Some(val) = scale_crop {
-                writer.write_flatten_text("ScaleCrop", val)?;
+                writer.write_flatten_text("ScaleCrop", val, false)?;
             }
             if let Some(val) = company {
-                writer.write_flatten_text("Company", val)?;
+                writer.write_flatten_text("Company", val, false)?;
             }
             if let Some(val) = links_up_to_date {
-                writer.write_flatten_text("LinksUpToDate", val)?;
+                writer.write_flatten_text("LinksUpToDate", val, false)?;
             }
             if let Some(val) = characters_with_spaces {
-                writer.write_flatten_text("CharactersWithSpaces", val)?;
+                writer.write_flatten_text("CharactersWithSpaces", val, false)?;
             }
             if let Some(val) = shared_doc {
-                writer.write_flatten_text("SharedDoc", val)?;
+                writer.write_flatten_text("SharedDoc", val, false)?;
             }
             if let Some(val) = hyperlinks_changed {
-                writer.write_flatten_text("HyperlinksChanged", val)?;
+                writer.write_flatten_text("HyperlinksChanged", val, false)?;
             }
             if let Some(val) = app_version {
-                writer.write_flatten_text("AppVersion", val)?;
+                writer.write_flatten_text("AppVersion", val, false)?;
             }
             writer.write_element_end_close("Properties")?;
         }

--- a/src/core.rs
+++ b/src/core.rs
@@ -57,25 +57,25 @@ impl<'a> XmlWrite for Core<'a> {
         } else {
             writer.write_element_end_open()?;
             if let Some(val) = title {
-                writer.write_flatten_text("dc:title", val)?;
+                writer.write_flatten_text("dc:title", val, false)?;
             }
             if let Some(val) = subject {
-                writer.write_flatten_text("dc:subject", val)?;
+                writer.write_flatten_text("dc:subject", val, false)?;
             }
             if let Some(val) = creator {
-                writer.write_flatten_text("dc:creator", val)?;
+                writer.write_flatten_text("dc:creator", val, false)?;
             }
             if let Some(val) = keywords {
-                writer.write_flatten_text("cp:keywords", val)?;
+                writer.write_flatten_text("cp:keywords", val, false)?;
             }
             if let Some(val) = description {
-                writer.write_flatten_text("dc:description", val)?;
+                writer.write_flatten_text("dc:description", val, false)?;
             }
             if let Some(val) = last_modified_by {
-                writer.write_flatten_text("cp:lastModifiedBy", val)?;
+                writer.write_flatten_text("cp:lastModifiedBy", val, false)?;
             }
             if let Some(val) = revision {
-                writer.write_flatten_text("cp:revision", val)?;
+                writer.write_flatten_text("cp:revision", val, false)?;
             }
             writer.write_element_end_close("cp:coreProperties")?;
         }

--- a/src/document/body.rs
+++ b/src/document/body.rs
@@ -3,6 +3,7 @@ use strong_xml::{XmlRead, XmlWrite};
 
 use crate::__xml_test_suites;
 use crate::document::{Paragraph, Table};
+use std::ops::{Deref, DerefMut};
 
 /// Document Body
 ///
@@ -17,28 +18,24 @@ pub struct Body<'a> {
 }
 
 impl<'a> Body<'a> {
-    pub fn push<T: Into<BodyContent<'a>>>(&mut self, content: T) -> &mut Self {
+    pub fn add_content<T: Into<BodyContent<'a>>>(&mut self, content: T) -> &mut Self {
         self.content.push(content.into());
         self
     }
+}
 
-    // pub fn iter_text(&self) -> impl Iterator<Item = &Cow<'a, str>> {
-    //     self.content
-    //         .iter()
-    //         .filter_map(|content| match content {
-    //             BodyContent::Paragraph(para) => Some(para.iter_text()),
-    //         })
-    //         .flatten()
-    // }
+impl<'a> Deref for Body<'a> {
+    type Target = Vec<BodyContent<'a>>;
 
-    // pub fn iter_text_mut(&mut self) -> impl Iterator<Item = &mut Cow<'a, str>> {
-    //     self.content
-    //         .iter_mut()
-    //         .filter_map(|content| match content {
-    //             BodyContent::Paragraph(para) => Some(para.iter_text_mut()),
-    //         })
-    //         .flatten()
-    // }
+    fn deref(&self) -> &Self::Target {
+        &self.content
+    }
+}
+
+impl<'a> DerefMut for Body<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.content
+    }
 }
 
 /// A set of elements that can be contained in the body

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -26,6 +26,7 @@ use strong_xml::{XmlRead, XmlResult, XmlWrite, XmlWriter};
 
 use crate::__xml_test_suites;
 use crate::schema::SCHEMA_MAIN;
+use std::ops::{Deref, DerefMut};
 
 /// The root element of the main document part.
 #[derive(Debug, Default, XmlRead)]
@@ -38,9 +39,23 @@ pub struct Document<'a> {
 }
 
 impl<'a> Document<'a> {
-    pub fn push<T: Into<BodyContent<'a>>>(&mut self, content: T) -> &mut Self {
-        self.body.push(content);
+    pub fn add_content<T: Into<BodyContent<'a>>>(&mut self, content: T) -> &mut Self {
+        self.body.add_content(content);
         self
+    }
+}
+
+impl<'a> Deref for Document<'a> {
+    type Target = Body<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.body
+    }
+}
+
+impl<'a> DerefMut for Document<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.body
     }
 }
 

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -165,8 +165,8 @@ impl DocxFile {
             app,
             content_types,
             core,
-            document_rels,
             document,
+            document_rels,
             font_table,
             rels,
             styles,
@@ -180,7 +180,7 @@ impl DocxFile {
     }
 
     /// Parses content into `Docx` struct
-    pub fn parse<'a>(&'a self) -> DocxResult<Docx<'a>> {
+    pub fn parse(&self) -> DocxResult<Docx> {
         let app = if let Some(content) = &self.app {
             Some(App::from_str(content)?)
         } else {
@@ -220,13 +220,13 @@ impl DocxFile {
 
         Ok(Docx {
             app,
-            content_types,
             core,
+            content_types,
             document,
-            document_rels,
             font_table,
-            rels,
             styles,
+            rels,
+            document_rels,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! // create a new paragraph and insert it
 //! let para = Paragraph::default().push_text("Lorem Ipsum");
-//! docx.document.push(para);
+//! docx.document.add_content(para);
 //!
 //! docx.write_file("demo.docx").unwrap();
 //! ```
@@ -40,7 +40,7 @@
 //! let mut docx = docx.parse().unwrap();
 //!
 //! let para = Paragraph::default().push_text("Lorem Ipsum");
-//! docx.document.push(para);
+//! docx.document.add_content(para);
 //!
 //! docx.write_file("origin_appended.docx").unwrap();
 //! ```


### PR DESCRIPTION
- Clippy fixes
- Strong Xml 0.6
- `Document` and `Body` now implement `Deref` and `DerefMut` to the content vector:
   This allows to call iterator methods on both `Document` and `Body`
- renamed push methods to add_content to avoid conflict with the `Deref` implementation