### PR TITLE
fix(strong-xml): `write_flatten_text` api changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 **/*.rs.bk
 *.docx
 Cargo.lock
+
+# IDE
+.vscode/
+.idea/
+*.iml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "docx"
 version = "1.1.3"
 authors = ["PoiScript <poiscript@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/PoiScript/docx-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docx"
-version = "1.1.2"
+version = "1.1.3"
 authors = ["PoiScript <poiscript@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -10,10 +10,10 @@ description = "A Rust library for parsing and generating docx files."
 keywords = ["docx", "generator", "openxml", "parser"]
 
 [dependencies]
-derive_more = "0.99.5"
-log = "0.4.8"
-strong-xml = { version = "0.5.0", features = ["log"] }
-zip = "0.5.5"
+derive_more = "0.99.17"
+log = "0.4.14"
+strong-xml = { version = "0.6.3", features = ["log"] }
+zip = "0.5.13"
 
 [dev-dependencies]
-env_logger = "0.7.1"
+env_logger = "0.9.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -117,52 +117,52 @@ impl<'a> XmlWrite for App<'a> {
         } else {
             writer.write_element_end_open()?;
             if let Some(val) = template {
-                writer.write_flatten_text("Template", val)?;
+                writer.write_flatten_text("Template", val, true)?;
             }
             if let Some(val) = total_time {
-                writer.write_flatten_text("TotalTime", val)?;
+                writer.write_flatten_text("TotalTime", val, true)?;
             }
             if let Some(val) = pages {
-                writer.write_flatten_text("Pages", val)?;
+                writer.write_flatten_text("Pages", val, true)?;
             }
             if let Some(val) = words {
-                writer.write_flatten_text("Words", val)?;
+                writer.write_flatten_text("Words", val, true)?;
             }
             if let Some(val) = characters {
-                writer.write_flatten_text("Characters", val)?;
+                writer.write_flatten_text("Characters", val, true)?;
             }
             if let Some(val) = application {
-                writer.write_flatten_text("Application", val)?;
+                writer.write_flatten_text("Application", val, true)?;
             }
             if let Some(val) = doc_security {
-                writer.write_flatten_text("DocSecurity", val)?;
+                writer.write_flatten_text("DocSecurity", val, true)?;
             }
             if let Some(val) = lines {
-                writer.write_flatten_text("Lines", val)?;
+                writer.write_flatten_text("Lines", val, true)?;
             }
             if let Some(val) = paragraphs {
-                writer.write_flatten_text("Paragraphs", val)?;
+                writer.write_flatten_text("Paragraphs", val, true)?;
             }
             if let Some(val) = scale_crop {
-                writer.write_flatten_text("ScaleCrop", val)?;
+                writer.write_flatten_text("ScaleCrop", val, true)?;
             }
             if let Some(val) = company {
-                writer.write_flatten_text("Company", val)?;
+                writer.write_flatten_text("Company", val, true)?;
             }
             if let Some(val) = links_up_to_date {
-                writer.write_flatten_text("LinksUpToDate", val)?;
+                writer.write_flatten_text("LinksUpToDate", val, true)?;
             }
             if let Some(val) = characters_with_spaces {
-                writer.write_flatten_text("CharactersWithSpaces", val)?;
+                writer.write_flatten_text("CharactersWithSpaces", val, true)?;
             }
             if let Some(val) = shared_doc {
-                writer.write_flatten_text("SharedDoc", val)?;
+                writer.write_flatten_text("SharedDoc", val, true)?;
             }
             if let Some(val) = hyperlinks_changed {
-                writer.write_flatten_text("HyperlinksChanged", val)?;
+                writer.write_flatten_text("HyperlinksChanged", val, true)?;
             }
             if let Some(val) = app_version {
-                writer.write_flatten_text("AppVersion", val)?;
+                writer.write_flatten_text("AppVersion", val, true)?;
             }
             writer.write_element_end_close("Properties")?;
         }

--- a/src/core.rs
+++ b/src/core.rs
@@ -57,25 +57,25 @@ impl<'a> XmlWrite for Core<'a> {
         } else {
             writer.write_element_end_open()?;
             if let Some(val) = title {
-                writer.write_flatten_text("dc:title", val)?;
+                writer.write_flatten_text("dc:title", val, true)?;
             }
             if let Some(val) = subject {
-                writer.write_flatten_text("dc:subject", val)?;
+                writer.write_flatten_text("dc:subject", val, true)?;
             }
             if let Some(val) = creator {
-                writer.write_flatten_text("dc:creator", val)?;
+                writer.write_flatten_text("dc:creator", val, true)?;
             }
             if let Some(val) = keywords {
-                writer.write_flatten_text("cp:keywords", val)?;
+                writer.write_flatten_text("cp:keywords", val, true)?;
             }
             if let Some(val) = description {
-                writer.write_flatten_text("dc:description", val)?;
+                writer.write_flatten_text("dc:description", val, true)?;
             }
             if let Some(val) = last_modified_by {
-                writer.write_flatten_text("cp:lastModifiedBy", val)?;
+                writer.write_flatten_text("cp:lastModifiedBy", val, true)?;
             }
             if let Some(val) = revision {
-                writer.write_flatten_text("cp:revision", val)?;
+                writer.write_flatten_text("cp:revision", val, true)?;
             }
             writer.write_element_end_close("cp:coreProperties")?;
         }

--- a/src/document/hyperlink.rs
+++ b/src/document/hyperlink.rs
@@ -1,3 +1,5 @@
+#![allow(unused_must_use)]
+
 use std::borrow::Cow;
 use strong_xml::{XmlRead, XmlWrite};
 

--- a/src/document/paragraph.rs
+++ b/src/document/paragraph.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use derive_more::From;
 use std::borrow::Cow;
 use strong_xml::{XmlRead, XmlWrite};

--- a/src/document/run.rs
+++ b/src/document/run.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use derive_more::From;
 use std::borrow::Cow;
 use strong_xml::{XmlRead, XmlWrite};

--- a/src/document/table.rs
+++ b/src/document/table.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use strong_xml::{XmlRead, XmlWrite};
 
 use crate::{

--- a/src/document/table_cell.rs
+++ b/src/document/table_cell.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use derive_more::From;
 use strong_xml::{XmlRead, XmlWrite};
 

--- a/src/document/table_row.rs
+++ b/src/document/table_row.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use strong_xml::{XmlRead, XmlWrite};
 
 use crate::{__setter, __xml_test_suites, document::TableCell, formatting::TableRowProperty};

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -148,7 +148,7 @@ impl DocxFile {
                         file.read_to_string(&mut buffer)?;
                         Some(buffer)
                     }
-                };
+                }
             };
         }
 

--- a/src/formatting/numbering_property.rs
+++ b/src/formatting/numbering_property.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use strong_xml::{XmlRead, XmlWrite};
 
 use crate::__xml_test_suites;

--- a/src/styles/default_style.rs
+++ b/src/styles/default_style.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use strong_xml::{XmlRead, XmlWrite};
 
 use crate::{

--- a/src/styles/style.rs
+++ b/src/styles/style.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use std::borrow::Cow;
 use strong_xml::{XmlRead, XmlWrite};
 


### PR DESCRIPTION
- Fix #47 
- Fix following error

```rs
C:/Users/.cargo/bin/cargo.exe build --color=always --message-format=json-diagnostic-rendered-ansi --package docx --example table
   Compiling jetscii v0.4.4
error: unconstrained generic constant
   --> C:\Users\.cargo\registry\src\github.com-1ecc6299db9ec823\jetscii-0.4.4\src\simd.rs:110:13
    |
110 |             T::CONTROL_BYTE,
    |             ^^^^^^^^^^^^^^^
    |
    = help: try adding a `where` bound using this expression: `where [(); T::CONTROL_BYTE]:`

error: unconstrained generic constant
   --> C:\Users\.cargo\registry\src\github.com-1ecc6299db9ec823\jetscii-0.4.4\src\simd.rs:149:13
    |
149 |             T::CONTROL_BYTE,
    |             ^^^^^^^^^^^^^^^
    |
    = help: try adding a `where` bound using this expression: `where [(); T::CONTROL_BYTE]:`

error: aborting due to 2 previous errors

error: could not compile `jetscii` due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
error: build failed
Process finished with exit code 101
```